### PR TITLE
`customRender` 유틸

### DIFF
--- a/src/__test__/ReactQueryWrapper.tsx
+++ b/src/__test__/ReactQueryWrapper.tsx
@@ -1,0 +1,23 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+import { type PropsWithChildren, type ReactElement } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const ReactQueryWrapper = ({ children }: PropsWithChildren): ReactElement => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+    logger: {
+      // eslint-disable-next-line no-console
+      log: console.log,
+      warn: console.warn,
+      error: () => {},
+    },
+  });
+
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+};
+
+export default ReactQueryWrapper;

--- a/src/__test__/customRender.tsx
+++ b/src/__test__/customRender.tsx
@@ -1,0 +1,21 @@
+import { type PropsWithChildren, type ReactElement } from 'react';
+import { ThemeProvider } from '@emotion/react';
+import { render, type RenderOptions } from '@testing-library/react';
+
+import theme from '~/styles/theme';
+
+import ReactQueryWrapper from './ReactQueryWrapper';
+
+const RenderWithProviders = ({ children }: PropsWithChildren) => {
+  return (
+    <ReactQueryWrapper>
+      <ThemeProvider theme={theme}>{children}</ThemeProvider>
+    </ReactQueryWrapper>
+  );
+};
+
+const customRender = (ui: ReactElement, options?: RenderOptions) => {
+  return render(ui, { wrapper: RenderWithProviders, ...options });
+};
+
+export default customRender;


### PR DESCRIPTION
## 🤔 해결하려는 문제가 무엇인가요?

close #20 

## 🎉 변경 사항

- 컴포넌트를 테스트할 시 프로바이더가 필요한 경우에 사용할 수 있는 `customRender` 유틸을 개발했어요

### 사용 방법

```tsx
describe('compo', () => {
  test('foo', () => {
    customRender(<Foo />);
    screen.getByText('foo').toBeInTheDocument();
  });
})
```
